### PR TITLE
non-docker forwards should not be kept 

### DIFF
--- a/src/awk.firewall
+++ b/src/awk.firewall
@@ -24,8 +24,25 @@
         print ":DOCKER - [0:0]"
         print ":DOCKER-INGRESS - [0:0]"
     }
-    if (in_nat==1 && ($3 ~ /^(POSTROUTING|PREROUTING|DOCKER|DOCKER-INGRESS|OUTPUT)$/)) {print $0}
-    if (in_filter==1 && ($3 ~ /^(FORWARD|DOCKER-ISOLATION-STAGE-1|DOCKER-ISOLATION-STAGE-2|DOCKER|DOCKER-INGRESS|DOCKER-USER)$/)) {print $0}
-    if (in_nat==1 && $0 ~ /^COMMIT/ ) {print "COMMIT"}
-    if (in_filter==1 && $0 ~ /^COMMIT/ ) {print "COMMIT"}
+    if (in_nat==1) {
+        if ($3 ~ /^(POSTROUTING|PREROUTING|DOCKER|DOCKER-INGRESS|OUTPUT)$/) {print $0}
+        if ($0 ~ /^COMMIT/ ) {print "COMMIT"}
+    }
+    if (in_filter==1) {
+        if ($3 ~ /^(DOCKER-ISOLATION-STAGE-1|DOCKER-ISOLATION-STAGE-2|DOCKER|DOCKER-INGRESS|DOCKER-USER)$/) {
+            print $0
+        } else {
+            if ($7 ~ /^DOCKER$/) {
+                bridge=$5
+                print last_line
+            }
+            if (length(bridge) >0 && $5 == bridge) {
+                print $0
+            }
+        }
+        if ($0 ~ /^COMMIT/ ) {print "COMMIT"}
+    }
+
+    # remeber last line
+    last_line=$0
 }


### PR DESCRIPTION
In our firewall rule set, we have some `FORWARD` rules like
```
 [86636:107539495] -A FORWARD -j default-standard-rules
 [86529:107533975] -A FORWARD -j default-forward-rules
```
In that case the restore will "crash" because the iptable jails (e.g. `default-standard-rules`) are not accessible anymore and a restore is impossible.
Because docker forward rules look always alike:
```
[0:0] -A FORWARD -o br-7669491af7b0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
[0:0] -A FORWARD -o br-7669491af7b0 -j DOCKER
[0:0] -A FORWARD -i br-7669491af7b0 ! -o br-7669491af7b0 -j ACCEPT
[0:0] -A FORWARD -i br-7669491af7b0 -o br-7669491af7b0 -j ACCEPT
```
we changed the AWK to look for the `DOCKER` keyword and store the interface name (e.g. `br-7669491af7b0`). If this interface is in the previous line, it will be printed out. This rule is applied to the following lines as well. So if the same interface name is found, a line gets printed out. This will ensure, that the docker rule is complete and that only docker forwards are taken into the restore.