### PR TITLE
Some suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ my-public-ip-address
 
 Before install iptables-docker please read this notes:
 
-* both local instal and ansible install configure your system to use **iptables-legacy**
+* both local install and ansible install configure your system to use **iptables-legacy**
 * by default **only** port 22 is allowed
 * ufw and firewalld will be permanently **disabled**
 * filtering on all docker interfaces is disabled

--- a/roles/iptables-docker/tasks/install.yml
+++ b/roles/iptables-docker/tasks/install.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: Disable firewall services
-  service: 
-    name: "{{ item }}" 
-    state: stopped 
+  service:
+    name: "{{ item }}"
+    state: stopped
     enabled: no
   with_items: "{{ firewall_services }}"
-  ignore_errors: yes
+  when: item in services
 
 - name: render iptables-docker.sh
   template:

--- a/roles/iptables-docker/tasks/iptables-legacy.yml
+++ b/roles/iptables-docker/tasks/iptables-legacy.yml
@@ -2,9 +2,9 @@
 - name: check iptables version
   shell: iptables --version
   register: iptables_version
-  ignore_errors: yes
+  changed_when: false
 
-- block:  
+- block:
     - alternatives:
         name: iptables
         path: /usr/sbin/iptables-legacy

--- a/roles/iptables-docker/tasks/main.yml
+++ b/roles/iptables-docker/tasks/main.yml
@@ -1,18 +1,21 @@
 ---
-- include_tasks: 
+- name: Populate service facts
+  ansible.builtin.service_facts:
+
+- include_tasks:
     file: iptables-legacy.yml
     apply:
       tags: iptables-legacy,legacy
   tags: iptables-legacy,legacy
 
-- include_tasks: 
+- include_tasks:
     file: install.yml
     apply:
       tags: iptables-install,install
   tags: iptables-install,install
   when: iptables_docker_uninstall is false
 
-- include_tasks: 
+- include_tasks:
     file: uninstall.yml
     apply:
       tags: uninstall-install,uninstall


### PR DESCRIPTION
added missing l to fix instal typo in README.md
fixed the always changed result for check iptables version
fixed the errors when missing services, but requires ansible 2.5 or greater

relevent tested outputs are below

# now doesn't report as changed everytime the version is checked
TASK [roles/iptables-docker : check iptables version] ******************************************************************
ok: [myhost]

# now skips missing services instead of ugly red ignored errors
TASK [roles/iptables-docker : Disable firewall services] ***************************************************************
ok: [myhost] => (item=ufw)
skipping: [myhost] => (item=firewalld) 
