### PR TITLE
make_firewall_backups_only_writeable_for_owner

### DIFF
--- a/roles/iptables-docker/templates/iptables-docker.sh.j2
+++ b/roles/iptables-docker/templates/iptables-docker.sh.j2
@@ -50,6 +50,8 @@ start() {
 
     mkdir -p /tmp/backup/firewall
     IPTABLES_SAVE_FILE="/tmp/backup/firewall/rules_`date +%Y%m%d%H%M%S%N`"
+    touch "$IPTABLES_SAVE_FILE"
+    chmod 600 "$IPTABLES_SAVE_FILE"
     iptables-save -c >"$IPTABLES_SAVE_FILE"
 
     # flush all rules
@@ -163,6 +165,8 @@ stop() {
 
     mkdir -p /tmp/backup/firewall
     IPTABLES_SAVE_FILE="/tmp/backup/firewall/rules_`date +%Y%m%d%H%M%S%N`"
+    touch "$IPTABLES_SAVE_FILE"
+    chmod 600 "$IPTABLES_SAVE_FILE"
     iptables-save -c >"$IPTABLES_SAVE_FILE"
 
     # set the default policy to ACCEPT

--- a/src/iptables-docker.sh
+++ b/src/iptables-docker.sh
@@ -50,6 +50,8 @@ start() {
 
     mkdir -p /tmp/backup/firewall
     IPTABLES_SAVE_FILE="/tmp/backup/firewall/rules_`date +%Y%m%d%H%M%S%N`"
+    touch "$IPTABLES_SAVE_FILE"
+    chmod 600 "$IPTABLES_SAVE_FILE"
     iptables-save -c >"$IPTABLES_SAVE_FILE"
 
     # flush all rules
@@ -153,6 +155,8 @@ stop() {
 
     mkdir -p /tmp/backup/firewall
     IPTABLES_SAVE_FILE="/tmp/backup/firewall/rules_`date +%Y%m%d%H%M%S%N`"
+    touch "$IPTABLES_SAVE_FILE"
+    chmod 600 "$IPTABLES_SAVE_FILE"
     iptables-save -c >"$IPTABLES_SAVE_FILE"
 
     # set the default policy to ACCEPT


### PR DESCRIPTION
With this we guarantee only the owner of the firewall backups can write and read the files